### PR TITLE
fix state change handler for removed entities

### DIFF
--- a/custom_components/person_location/__init__.py
+++ b/custom_components/person_location/__init__.py
@@ -459,6 +459,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         old_state = event.data["old_state"]
         new_state = event.data["new_state"]
 
+        if new_state is None:
+            _LOGGER.debug("Skipping removed entity: %s", entity_id)
+            return
+
         _LOGGER.debug(
             "[_handle_device_tracker_state_change] === Start === (%s)", entity_id
         )


### PR DESCRIPTION
Fixes a crash in the device tracker state change handler when Home Assistant sends a state_changed event with new_state set to None. Removed entities are now skipped safely instead of causing an AttributeError.